### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -3,13 +3,13 @@ processByte	KEYWORD2
 setTable	KEYWORD2
 setEndByte	KEYWORD2
 setHandlerForCmdNotFound	KEYWORD2
-useStartByteSet KEYWORD2
-getLong	        KEYWORD2
-getInt          KEYWORD2
+useStartByteSet	KEYWORD2
+getLong	KEYWORD2
+getInt	KEYWORD2
 getFloat	KEYWORD2
 setEndByte	KEYWORD2
 numCmds	KEYWORD2
 cmdString	KEYWORD2
 cmdDesc	KEYWORD2
-version		KEYWORD2
+version	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords